### PR TITLE
Fixed null on received file error

### DIFF
--- a/DuggaSys/.gitignore
+++ b/DuggaSys/.gitignore
@@ -1,0 +1,1 @@
+submissions

--- a/DuggaSys/showDuggaservice.php
+++ b/DuggaSys/showDuggaservice.php
@@ -313,7 +313,7 @@ foreach($query->fetchAll() as $row) {
 			  $movname=$currcvd."/submissions/".$courseid."/".$coursevers."/".$duggaid."/".$userdir."/".$row['filename'].$row['seq'].".".$row['extension'];	
 
 			  if (file_exists ($movname)){
-						$content=html_entity_decode(file_get_contents($movname));
+						$content=file_get_contents($movname);
 			  }else{
 						$content="File does not exist";			  
 			  }

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -82,7 +82,9 @@ function returnedDugga(data)
 		if (duggaFiles.length > 0){
 			for (var l=0; l<duggaFiles.length; l++){
 				if (duggaFiles[l].kind == "3"){
-					if (document.getElementById(duggaFiles[l].fieldnme+"Text") != null) document.getElementById(duggaFiles[l].fieldnme+"Text").value=decodeURIComponent(duggaFiles[l].content);
+					if (document.getElementById(duggaFiles[l].fieldnme+"Text") != null){
+							document.getElementById(duggaFiles[l].fieldnme+"Text").value=duggaFiles[l].content;
+					} 
 				}
 			}	
 		} else {

--- a/DuggaSys/templates/generic_dugga_file_receive.js
+++ b/DuggaSys/templates/generic_dugga_file_receive.js
@@ -83,7 +83,8 @@ function returnedDugga(data)
 			for (var l=0; l<duggaFiles.length; l++){
 				if (duggaFiles[l].kind == "3"){
 					if (document.getElementById(duggaFiles[l].fieldnme+"Text") != null){
-							document.getElementById(duggaFiles[l].fieldnme+"Text").value=duggaFiles[l].content;
+							//alert(duggaFiles[l].content);
+							document.getElementById(duggaFiles[l].fieldnme+"Text").innerHTML=duggaFiles[l].content;
 					} 
 				}
 			}	
@@ -192,11 +193,17 @@ function showFacit(param, uanswer, danswer, userStats, files)
 
 		}
 		duggaFiles = files;
+
+		// ----------------========#############========----------------
+		// This is in show facit marking view NOT official running version!
+		// ----------------========#############========----------------
 		
 		if (duggaFiles.length > 0){
 			for (var l=0; l<duggaFiles.length; l++){
 				if (duggaFiles[l].kind == "3"){
-					if (document.getElementById(duggaFiles[l].fieldnme+"Text") != null) document.getElementById(duggaFiles[l].fieldnme+"Text").value=duggaFiles[l].content;
+					if (document.getElementById(duggaFiles[l].fieldnme+"Text") != null){
+					 	document.getElementById(duggaFiles[l].fieldnme+"Text").value=duggaFiles[l].content;
+					}
 				}
 			}	
 		} else {


### PR DESCRIPTION
I fixed the javascript error that breaks text submissions if there are swedish characters in the text.

This was due to double-uri-decoding the content. e.g. encoding an already encoded string.
